### PR TITLE
feat: add handleEvent call

### DIFF
--- a/Sources/AccrueIosSDK/AccrueContextData.swift
+++ b/Sources/AccrueIosSDK/AccrueContextData.swift
@@ -13,11 +13,11 @@ public class AccrueContextData: ObservableObject {
     public init(
         userData: AccrueUserData = AccrueUserData(),
         settingsData: AccrueSettingsData = AccrueSettingsData(),
-        actions:AccrueActionsData = AccrueActionsData()
+        actions: AccrueActionsData = AccrueActionsData()
     ) {
         self.userData = userData
         self.settingsData = settingsData
-        self.actions = AccrueActionsData()
+        self.actions = actions
     }
     public func updateUserData(referenceId: String?, email: String?, phoneNumber: String?) {
         userData = AccrueUserData(referenceId: referenceId, email: email, phoneNumber: phoneNumber)

--- a/Sources/AccrueIosSDK/AccrueContextData.swift
+++ b/Sources/AccrueIosSDK/AccrueContextData.swift
@@ -27,87 +27,88 @@ public class AccrueContextData: ObservableObject {
     }
     public func setAction(action: String) {
         actions = AccrueActionsData(action: action)
-    
-}
-
-public struct AccrueUserData {
-    public let referenceId: String?
-    public let email: String?
-    public let phoneNumber: String?
-    
-    public init(
-        referenceId: String? = nil,
-        email: String? = nil,
-        phoneNumber: String? = nil
-    ) {
-        self.referenceId = referenceId
-        self.email = email
-        self.phoneNumber = phoneNumber
+        
     }
-}
-
-public struct AccrueActionsData {
-    public let action: String?
     
-    public init( action: String? = nil) {
-        self.action = action
+    public struct AccrueUserData {
+        public let referenceId: String?
+        public let email: String?
+        public let phoneNumber: String?
+        
+        public init(
+            referenceId: String? = nil,
+            email: String? = nil,
+            phoneNumber: String? = nil
+        ) {
+            self.referenceId = referenceId
+            self.email = email
+            self.phoneNumber = phoneNumber
+        }
     }
-}
-
-public struct AccrueSettingsData {
-    public let shouldInheritAuthentication: Bool
     
-    public init( shouldInheritAuthentication: Bool = true) {
-        self.shouldInheritAuthentication = shouldInheritAuthentication
+    public struct AccrueActionsData {
+        public let action: String?
+        
+        public init( action: String? = nil) {
+            self.action = action
+        }
     }
-}
-
-public struct AccrueDeviceContextData {
-    public let sdk: String = "iOS"
-    public let sdkVersion: String?
-    public let brand: String?
-    public let deviceName: String?
-    public let deviceType: String?
-    public let deviceYearClass: Double?
-    public let isDevice: Bool
-    public let manufacturer: String?
-    public let modelName: String?
-    public let osBuildId: String?
-    public let osInternalBuildId: String?
-    public let osName: String?
-    public let osVersion: String?
-    // iOS only
-    public let modelId: String?
     
-    public init(sdkVersion: String? = nil, brand: String? = nil, deviceName: String? = nil, deviceType: String? = nil, deviceYearClass: Double? = 0, isDevice: Bool? = true, manufacturer: String? = nil, modelName: String? = nil, osBuildId: String? = nil, osInternalBuildId: String? = nil, osName: String? = nil, osVersion: String? = nil, modelId: String? = nil) {
+    public struct AccrueSettingsData {
+        public let shouldInheritAuthentication: Bool
+        
+        public init( shouldInheritAuthentication: Bool = true) {
+            self.shouldInheritAuthentication = shouldInheritAuthentication
+        }
+    }
+    
+    public struct AccrueDeviceContextData {
+        public let sdk: String = "iOS"
+        public let sdkVersion: String?
+        public let brand: String?
+        public let deviceName: String?
+        public let deviceType: String?
+        public let deviceYearClass: Double?
+        public let isDevice: Bool
+        public let manufacturer: String?
+        public let modelName: String?
+        public let osBuildId: String?
+        public let osInternalBuildId: String?
+        public let osName: String?
+        public let osVersion: String?
+        // iOS only
+        public let modelId: String?
+        
+        public init(sdkVersion: String? = nil, brand: String? = nil, deviceName: String? = nil, deviceType: String? = nil, deviceYearClass: Double? = 0, isDevice: Bool? = true, manufacturer: String? = nil, modelName: String? = nil, osBuildId: String? = nil, osInternalBuildId: String? = nil, osName: String? = nil, osVersion: String? = nil, modelId: String? = nil) {
 #if canImport(UIKit)
-        self.sdkVersion = sdkVersion ?? DeviceHelper.getPackageVersion()
-        self.brand = brand ?? "Apple"
-        self.deviceName = deviceName ?? UIDevice.current.name
-        self.deviceType = deviceType ?? UIDevice.current.model
-        self.deviceYearClass = deviceYearClass
-        self.isDevice = isDevice ?? true
-        self.manufacturer = manufacturer ?? "Apple"
-        self.modelName = modelName ?? UIDevice.current.model
-        self.osBuildId = osBuildId ?? DeviceHelper.getInternalOSVersion()
-        self.osInternalBuildId = osInternalBuildId ?? DeviceHelper.getInternalOSVersion()
-        self.osName = osName ?? UIDevice.current.systemName
-        self.osVersion = osVersion ?? UIDevice.current.systemVersion
-        self.modelId = modelId ?? DeviceHelper.getModelIdentifier()
+            self.sdkVersion = sdkVersion ?? DeviceHelper.getPackageVersion()
+            self.brand = brand ?? "Apple"
+            self.deviceName = deviceName ?? UIDevice.current.name
+            self.deviceType = deviceType ?? UIDevice.current.model
+            self.deviceYearClass = deviceYearClass
+            self.isDevice = isDevice ?? true
+            self.manufacturer = manufacturer ?? "Apple"
+            self.modelName = modelName ?? UIDevice.current.model
+            self.osBuildId = osBuildId ?? DeviceHelper.getInternalOSVersion()
+            self.osInternalBuildId = osInternalBuildId ?? DeviceHelper.getInternalOSVersion()
+            self.osName = osName ?? UIDevice.current.systemName
+            self.osVersion = osVersion ?? UIDevice.current.systemVersion
+            self.modelId = modelId ?? DeviceHelper.getModelIdentifier()
 #else
-        self.sdkVersion = sdkVersion ?? DeviceHelper.getPackageVersion()
-        self.brand = brand ?? "Apple"
-        self.deviceName = deviceName
-        self.deviceType = deviceType
-        self.deviceYearClass = deviceYearClass
-        self.isDevice = isDevice ?? true
-        self.manufacturer = manufacturer ?? "Apple"
-        self.modelName = modelName
-        self.osBuildId = osBuildId ?? DeviceHelper.getInternalOSVersion()
-        self.osInternalBuildId = osInternalBuildId ?? DeviceHelper.getInternalOSVersion()
-        self.osName = osName
-        self.osVersion = osVersion
-        self.modelId = modelId ?? DeviceHelper.getModelIdentifier()
+            self.sdkVersion = sdkVersion ?? DeviceHelper.getPackageVersion()
+            self.brand = brand ?? "Apple"
+            self.deviceName = deviceName
+            self.deviceType = deviceType
+            self.deviceYearClass = deviceYearClass
+            self.isDevice = isDevice ?? true
+            self.manufacturer = manufacturer ?? "Apple"
+            self.modelName = modelName
+            self.osBuildId = osBuildId ?? DeviceHelper.getInternalOSVersion()
+            self.osInternalBuildId = osInternalBuildId ?? DeviceHelper.getInternalOSVersion()
+            self.osName = osName
+            self.osVersion = osVersion
+            self.modelId = modelId ?? DeviceHelper.getModelIdentifier()
 #endif
+        }
     }
 }

--- a/Sources/AccrueIosSDK/AccrueContextData.swift
+++ b/Sources/AccrueIosSDK/AccrueContextData.swift
@@ -8,13 +8,16 @@ import UIKit
 public class AccrueContextData: ObservableObject {
     @Published public var  userData: AccrueUserData
     @Published public var  settingsData: AccrueSettingsData
+    @Published public var  actions: AccrueActionsData
     
     public init(
         userData: AccrueUserData = AccrueUserData(),
-        settingsData: AccrueSettingsData = AccrueSettingsData()
+        settingsData: AccrueSettingsData = AccrueSettingsData(),
+        actions:AccrueActionsData = AccrueActionsData()
     ) {
         self.userData = userData
         self.settingsData = settingsData
+        self.actions = AccrueActionsData()
     }
     public func updateUserData(referenceId: String?, email: String?, phoneNumber: String?) {
         userData = AccrueUserData(referenceId: referenceId, email: email, phoneNumber: phoneNumber)
@@ -22,6 +25,8 @@ public class AccrueContextData: ObservableObject {
     public func updateSettingsData(shouldInheritAuthentication: Bool) {
         settingsData = AccrueSettingsData(shouldInheritAuthentication: shouldInheritAuthentication)
     }
+    public func setAction(action: String) {
+        actions = AccrueActionsData(action: action)
     
 }
 
@@ -38,6 +43,14 @@ public struct AccrueUserData {
         self.referenceId = referenceId
         self.email = email
         self.phoneNumber = phoneNumber
+    }
+}
+
+public struct AccrueActionsData {
+    public let action: String?
+    
+    public init( action: String? = nil) {
+        self.action = action
     }
 }
 

--- a/Sources/AccrueIosSDK/AccrueContextData.swift
+++ b/Sources/AccrueIosSDK/AccrueContextData.swift
@@ -27,7 +27,9 @@ public class AccrueContextData: ObservableObject {
     }
     public func setAction(action: String) {
         actions = AccrueActionsData(action: action)
-        
+    }
+    public func clearAction(){
+        actions = AccrueActionsData()
     }
     
 }

--- a/Sources/AccrueIosSDK/AccrueContextData.swift
+++ b/Sources/AccrueIosSDK/AccrueContextData.swift
@@ -30,85 +30,86 @@ public class AccrueContextData: ObservableObject {
         
     }
     
-    public struct AccrueUserData {
-        public let referenceId: String?
-        public let email: String?
-        public let phoneNumber: String?
-        
-        public init(
-            referenceId: String? = nil,
-            email: String? = nil,
-            phoneNumber: String? = nil
-        ) {
-            self.referenceId = referenceId
-            self.email = email
-            self.phoneNumber = phoneNumber
-        }
-    }
+}
+public struct AccrueUserData {
+    public let referenceId: String?
+    public let email: String?
+    public let phoneNumber: String?
     
-    public struct AccrueActionsData {
-        public let action: String?
-        
-        public init( action: String? = nil) {
-            self.action = action
-        }
-    }
-    
-    public struct AccrueSettingsData {
-        public let shouldInheritAuthentication: Bool
-        
-        public init( shouldInheritAuthentication: Bool = true) {
-            self.shouldInheritAuthentication = shouldInheritAuthentication
-        }
-    }
-    
-    public struct AccrueDeviceContextData {
-        public let sdk: String = "iOS"
-        public let sdkVersion: String?
-        public let brand: String?
-        public let deviceName: String?
-        public let deviceType: String?
-        public let deviceYearClass: Double?
-        public let isDevice: Bool
-        public let manufacturer: String?
-        public let modelName: String?
-        public let osBuildId: String?
-        public let osInternalBuildId: String?
-        public let osName: String?
-        public let osVersion: String?
-        // iOS only
-        public let modelId: String?
-        
-        public init(sdkVersion: String? = nil, brand: String? = nil, deviceName: String? = nil, deviceType: String? = nil, deviceYearClass: Double? = 0, isDevice: Bool? = true, manufacturer: String? = nil, modelName: String? = nil, osBuildId: String? = nil, osInternalBuildId: String? = nil, osName: String? = nil, osVersion: String? = nil, modelId: String? = nil) {
-#if canImport(UIKit)
-            self.sdkVersion = sdkVersion ?? DeviceHelper.getPackageVersion()
-            self.brand = brand ?? "Apple"
-            self.deviceName = deviceName ?? UIDevice.current.name
-            self.deviceType = deviceType ?? UIDevice.current.model
-            self.deviceYearClass = deviceYearClass
-            self.isDevice = isDevice ?? true
-            self.manufacturer = manufacturer ?? "Apple"
-            self.modelName = modelName ?? UIDevice.current.model
-            self.osBuildId = osBuildId ?? DeviceHelper.getInternalOSVersion()
-            self.osInternalBuildId = osInternalBuildId ?? DeviceHelper.getInternalOSVersion()
-            self.osName = osName ?? UIDevice.current.systemName
-            self.osVersion = osVersion ?? UIDevice.current.systemVersion
-            self.modelId = modelId ?? DeviceHelper.getModelIdentifier()
-#else
-            self.sdkVersion = sdkVersion ?? DeviceHelper.getPackageVersion()
-            self.brand = brand ?? "Apple"
-            self.deviceName = deviceName
-            self.deviceType = deviceType
-            self.deviceYearClass = deviceYearClass
-            self.isDevice = isDevice ?? true
-            self.manufacturer = manufacturer ?? "Apple"
-            self.modelName = modelName
-            self.osBuildId = osBuildId ?? DeviceHelper.getInternalOSVersion()
-            self.osInternalBuildId = osInternalBuildId ?? DeviceHelper.getInternalOSVersion()
-            self.osName = osName
-            self.osVersion = osVersion
-            self.modelId = modelId ?? DeviceHelper.getModelIdentifier()
-#endif
-        }
+    public init(
+        referenceId: String? = nil,
+        email: String? = nil,
+        phoneNumber: String? = nil
+    ) {
+        self.referenceId = referenceId
+        self.email = email
+        self.phoneNumber = phoneNumber
     }
 }
+
+public struct AccrueActionsData {
+    public let action: String?
+    
+    public init( action: String? = nil) {
+        self.action = action
+    }
+}
+
+public struct AccrueSettingsData {
+    public let shouldInheritAuthentication: Bool
+    
+    public init( shouldInheritAuthentication: Bool = true) {
+        self.shouldInheritAuthentication = shouldInheritAuthentication
+    }
+}
+
+public struct AccrueDeviceContextData {
+    public let sdk: String = "iOS"
+    public let sdkVersion: String?
+    public let brand: String?
+    public let deviceName: String?
+    public let deviceType: String?
+    public let deviceYearClass: Double?
+    public let isDevice: Bool
+    public let manufacturer: String?
+    public let modelName: String?
+    public let osBuildId: String?
+    public let osInternalBuildId: String?
+    public let osName: String?
+    public let osVersion: String?
+    // iOS only
+    public let modelId: String?
+    
+    public init(sdkVersion: String? = nil, brand: String? = nil, deviceName: String? = nil, deviceType: String? = nil, deviceYearClass: Double? = 0, isDevice: Bool? = true, manufacturer: String? = nil, modelName: String? = nil, osBuildId: String? = nil, osInternalBuildId: String? = nil, osName: String? = nil, osVersion: String? = nil, modelId: String? = nil) {
+#if canImport(UIKit)
+        self.sdkVersion = sdkVersion ?? DeviceHelper.getPackageVersion()
+        self.brand = brand ?? "Apple"
+        self.deviceName = deviceName ?? UIDevice.current.name
+        self.deviceType = deviceType ?? UIDevice.current.model
+        self.deviceYearClass = deviceYearClass
+        self.isDevice = isDevice ?? true
+        self.manufacturer = manufacturer ?? "Apple"
+        self.modelName = modelName ?? UIDevice.current.model
+        self.osBuildId = osBuildId ?? DeviceHelper.getInternalOSVersion()
+        self.osInternalBuildId = osInternalBuildId ?? DeviceHelper.getInternalOSVersion()
+        self.osName = osName ?? UIDevice.current.systemName
+        self.osVersion = osVersion ?? UIDevice.current.systemVersion
+        self.modelId = modelId ?? DeviceHelper.getModelIdentifier()
+#else
+        self.sdkVersion = sdkVersion ?? DeviceHelper.getPackageVersion()
+        self.brand = brand ?? "Apple"
+        self.deviceName = deviceName
+        self.deviceType = deviceType
+        self.deviceYearClass = deviceYearClass
+        self.isDevice = isDevice ?? true
+        self.manufacturer = manufacturer ?? "Apple"
+        self.modelName = modelName
+        self.osBuildId = osBuildId ?? DeviceHelper.getInternalOSVersion()
+        self.osInternalBuildId = osInternalBuildId ?? DeviceHelper.getInternalOSVersion()
+        self.osName = osName
+        self.osVersion = osVersion
+        self.modelId = modelId ?? DeviceHelper.getModelIdentifier()
+#endif
+    }
+}
+

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -14,7 +14,7 @@ public struct AccrueWallet: View {
         let fallbackUrl = URL(string: "http://localhost:5173/webview")!
         let url = buildURL(isSandbox: isSandbox, url: url) ?? fallbackUrl
         
-        AccrueWebView(url: url, contextData: contextData, onAction: onAction)
+        return AccrueWebView(url: url, contextData: contextData, onAction: onAction)
     }
     #endif
  

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -14,8 +14,6 @@ public struct AccrueWallet: View {
 
         if let url = buildURL(isSandbox: isSandbox, url: url) {
             AccrueWebView(url: url, contextData: contextData, onAction: onAction)
-        }else {
-            AccrueWebView(url: "http://localhost:5173/webview/", contextData: contextData, onAction: onAction)
         }
     }
 #endif

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -7,24 +7,21 @@ public struct AccrueWallet: View {
     public let isSandbox: Bool
     public let url: String?
     public var onAction: ((String) -> Void)?
+    
     @ObservedObject var contextData: AccrueContextData
 #if os(iOS)
-    public var onHandleEvent: ((String) -> Void)? // Closure to expose handleEvent
-
     @State private var webViewCoordinator: WebView.Coordinator? // Store the Coordinator reference
 #endif
     
     
-    public init(merchantId: String, redirectionToken: String?,isSandbox: Bool,url: String? = nil, contextData: AccrueContextData = AccrueContextData(), onAction: ((String) -> Void)? = nil,  onHandleEvent: ((String) -> Void)? = nil) {
+    public init(merchantId: String, redirectionToken: String?,isSandbox: Bool,url: String? = nil, contextData: AccrueContextData = AccrueContextData(), onAction: ((String) -> Void)? = nil) {
         self.merchantId = merchantId
         self.redirectionToken = redirectionToken
         self.contextData = contextData
         self.isSandbox = isSandbox
         self.url = url
         self.onAction = onAction
-#if os(iOS)
-        self.onHandleEvent = onHandleEvent
-#endif
+ 
     }
     
     public var body: some View {
@@ -32,12 +29,7 @@ public struct AccrueWallet: View {
         if let url = buildURL(isSandbox: isSandbox, url: url) {
             WebView(url: url, contextData: contextData, onAction: onAction, onCoordinatorCreated: { coordinator in
                 self.webViewCoordinator = coordinator // Capture the Coordinator
-            }).onAppear {
-                // Pass the internal handleEvent logic to the parent via onHandleEvent
-                              if let onHandleEvent = onHandleEvent {
-                                  onHandleEvent(self.internalHandleEvent(_:))
-                              }
-            }
+            })
         } else {
             Text("Invalid URL")
         }
@@ -46,7 +38,7 @@ public struct AccrueWallet: View {
 #endif
     }
     
-    private func internalHandleEvent(event: String) {
+    public func handleEvent(event: String) {
 #if os(iOS)
         print("Calling internalHandleEvent...")
         if event == "AccrueTabPressed" {

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -8,8 +8,9 @@ public struct AccrueWallet: View {
     public let url: String?
     public var onAction: ((String) -> Void)?
     @ObservedObject var contextData: AccrueContextData
-    public var externalHandleEvent: ((String) -> Void)? // Closure to expose handleEvent
 #if os(iOS)
+    @State public var externalHandleEvent: ((String) -> Void)? // Closure to expose handleEvent
+
     @State private var webViewCoordinator: WebView.Coordinator? // Store the Coordinator reference
 #endif
     

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -10,7 +10,15 @@ public struct AccrueWallet: View {
     
     @ObservedObject var contextData: AccrueContextData
 #if os(iOS)
-    @State private var webViewCoordinator: WebView.Coordinator? // Store the Coordinator reference
+    private var WebViewComponent: AccrueWebView {
+
+        if let url = buildURL(isSandbox: isSandbox, url: url) {
+            AccrueWebView(url: url, contextData: contextData, onAction: onAction)
+        } else {
+            Text("Invalid URL")
+        }
+
+    }
 #endif
     
     
@@ -21,28 +29,21 @@ public struct AccrueWallet: View {
         self.isSandbox = isSandbox
         self.url = url
         self.onAction = onAction
- 
     }
     
     public var body: some View {
 #if os(iOS)
-        if let url = buildURL(isSandbox: isSandbox, url: url) {
-            WebView(url: url, contextData: contextData, onAction: onAction, onCoordinatorCreated: { coordinator in
-                self.webViewCoordinator = coordinator // Capture the Coordinator
-            })
-        } else {
-            Text("Invalid URL")
-        }
-#else
-        Text("Platform not supported")
+        WebViewComponent
 #endif
     }
     
     public func handleEvent(event: String) {
+        
+        print("Calling internalHandleEvent...\(event)")
 #if os(iOS)
-        print("Calling internalHandleEvent...")
         if event == "AccrueTabPressed" {
-            self.webViewCoordinator?.sendCustomEventGoToHomeScreen()
+            print("AccrueTab is pressed")
+            WebViewComponent.sendCustomEventGoToHomeScreen()
         }
 #endif
     }

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -41,7 +41,7 @@ public struct AccrueWallet: View {
 #if os(iOS)
         if event == "AccrueTabPressed" {
             print("AccrueTab is pressed")
-            WebViewComponent.makeCoordinator().sendCustomEventGoToHomeScreen()
+            WebViewComponent.coordinatorReference?.sendCustomEventGoToHomeScreen()
         }
 #endif
     }

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -11,7 +11,7 @@ public struct AccrueWallet: View {
     @ObservedObject var contextData: AccrueContextData
 #if os(iOS)
     private var WebViewComponent: AccrueWebView {
-        let fallbackUrl = URL(string: "http://localhost:5173/webview")!
+        let fallbackUrl = URL(string: AppConstants.productionUrl)!
         let url = buildURL(isSandbox: isSandbox, url: url) ?? fallbackUrl
         
         return AccrueWebView(url: url, contextData: contextData, onAction: onAction)

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -11,12 +11,13 @@ public struct AccrueWallet: View {
     @ObservedObject var contextData: AccrueContextData
 #if os(iOS)
     private var WebViewComponent: AccrueWebView {
-
-        let url = buildURL(isSandbox: isSandbox, url: url) ?? URLComponents(string: "http://localhost:5173/webview")?.url
+        let fallbackUrl = URL(string: "http://localhost:5173/webview")!
+        let url = buildURL(isSandbox: isSandbox, url: url) ?? fallbackUrl
         
         AccrueWebView(url: url, contextData: contextData, onAction: onAction)
     }
     #endif
+ 
     
     
     public init(merchantId: String, redirectionToken: String?,isSandbox: Bool,url: String? = nil, contextData: AccrueContextData = AccrueContextData(), onAction: ((String) -> Void)? = nil) {

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -34,7 +34,13 @@ public struct AccrueWallet: View {
         WebViewComponent
 #endif
     }
-   
+    
+    public func handleEvent(event: String) {
+        
+        print("Calling internalHandleEvent...\(event)")
+        contextData.setAction(action: event)
+    }
+       
     
     private func buildURL(isSandbox:Bool, url:String?) -> URL? {
         let apiBaseUrl: String

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -41,7 +41,7 @@ public struct AccrueWallet: View {
 #if os(iOS)
         if event == "AccrueTabPressed" {
             print("AccrueTab is pressed")
-            WebViewComponent.coordinatorReference?.sendCustomEventGoToHomeScreen()
+            WebViewComponent?.sendCustomEventGoToHomeScreen()
         }
 #endif
     }

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -34,18 +34,7 @@ public struct AccrueWallet: View {
         WebViewComponent
 #endif
     }
-    
-    public func handleEvent(event: String) {
-        
-        print("Calling internalHandleEvent...\(event)")
-#if os(iOS)
-        if event == "AccrueTabPressed" {
-            print("AccrueTab is pressed")
-            WebViewComponent.sendCustomEventGoToHomeScreen()
-        }
-#endif
-    }
-       
+   
     
     private func buildURL(isSandbox:Bool, url:String?) -> URL? {
         let apiBaseUrl: String

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -43,6 +43,7 @@ public struct AccrueWallet: View {
     
     private func internalHandleEvent(event: String) {
 #if os(iOS)
+        print("Calling internalHandleEvent...")
         if event == "AccrueTabPressed" {
             self.webViewCoordinator?.sendCustomEventGoToHomeScreen()
         }

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -12,9 +12,8 @@ public struct AccrueWallet: View {
 #if os(iOS)
     private var WebViewComponent: AccrueWebView {
 
-        if let url = buildURL(isSandbox: isSandbox, url: url) {
-            AccrueWebView(url: url, contextData: contextData, onAction: onAction)
-        }
+        let url = buildURL(isSandbox: isSandbox, url: url)
+        AccrueWebView(url: url, contextData: contextData, onAction: onAction)
     }
 #endif
     

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -15,7 +15,7 @@ public struct AccrueWallet: View {
         if let url = buildURL(isSandbox: isSandbox, url: url) {
             AccrueWebView(url: url, contextData: contextData, onAction: onAction)
         }else {
-            AccrueWebView(url: "http://", contextData: contextData, onAction: onAction)
+            AccrueWebView(url: "http://localhost:5173/webview/", contextData: contextData, onAction: onAction)
         }
     }
 #endif

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -12,10 +12,11 @@ public struct AccrueWallet: View {
 #if os(iOS)
     private var WebViewComponent: AccrueWebView {
 
-        let url = buildURL(isSandbox: isSandbox, url: url)
+        let url = buildURL(isSandbox: isSandbox, url: url) ?? URLComponents(string: "http://localhost:5173/webview")?.url
+        
         AccrueWebView(url: url, contextData: contextData, onAction: onAction)
     }
-#endif
+    #endif
     
     
     public init(merchantId: String, redirectionToken: String?,isSandbox: Bool,url: String? = nil, contextData: AccrueContextData = AccrueContextData(), onAction: ((String) -> Void)? = nil) {

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -9,20 +9,19 @@ public struct AccrueWallet: View {
     public var onAction: ((String) -> Void)?
     @ObservedObject var contextData: AccrueContextData
 #if os(iOS)
-    @State public var externalHandleEvent: ((String) -> Void)? // Closure to expose handleEvent
+    @State public var handleEvent: ((String) -> Void)? // Closure to expose handleEvent
 
     @State private var webViewCoordinator: WebView.Coordinator? // Store the Coordinator reference
 #endif
     
     
-    public init(merchantId: String, redirectionToken: String?,isSandbox: Bool,url: String? = nil, contextData: AccrueContextData = AccrueContextData(), onAction: ((String) -> Void)? = nil, externalHandleEvent: ((String) -> Void)? = nil) {
+    public init(merchantId: String, redirectionToken: String?,isSandbox: Bool,url: String? = nil, contextData: AccrueContextData = AccrueContextData(), onAction: ((String) -> Void)? = nil) {
         self.merchantId = merchantId
         self.redirectionToken = redirectionToken
         self.contextData = contextData
         self.isSandbox = isSandbox
         self.url = url
         self.onAction = onAction
-        self.externalHandleEvent = externalHandleEvent
     }
     
     public var body: some View {
@@ -32,7 +31,7 @@ public struct AccrueWallet: View {
                 self.webViewCoordinator = coordinator // Capture the Coordinator
             }).onAppear {
                 // Expose handleEvent logic to the parent
-                externalHandleEvent = self.handleEvent
+                handleEvent = self.internalHandleEvent
             }
         } else {
             Text("Invalid URL")
@@ -42,7 +41,7 @@ public struct AccrueWallet: View {
 #endif
     }
     
-    private func handleEvent(event: String) {
+    private func internalHandleEvent(event: String) {
 #if os(iOS)
         if event == "AccrueTabPressed" {
             self.webViewCoordinator?.sendCustomEventGoToHomeScreen()

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -14,10 +14,9 @@ public struct AccrueWallet: View {
 
         if let url = buildURL(isSandbox: isSandbox, url: url) {
             AccrueWebView(url: url, contextData: contextData, onAction: onAction)
-        } else {
-            Text("Invalid URL")
+        }else {
+            AccrueWebView(url: "http://", contextData: contextData, onAction: onAction)
         }
-
     }
 #endif
     

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -41,7 +41,7 @@ public struct AccrueWallet: View {
 #if os(iOS)
         if event == "AccrueTabPressed" {
             print("AccrueTab is pressed")
-            WebViewComponent?.sendCustomEventGoToHomeScreen()
+            WebViewComponent.sendCustomEventGoToHomeScreen()
         }
 #endif
     }

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -41,7 +41,7 @@ public struct AccrueWallet: View {
 #if os(iOS)
         if event == "AccrueTabPressed" {
             print("AccrueTab is pressed")
-            WebViewComponent.sendCustomEventGoToHomeScreen()
+            WebViewComponent.makeCoordinator().sendCustomEventGoToHomeScreen()
         }
 #endif
     }

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -9,19 +9,22 @@ public struct AccrueWallet: View {
     public var onAction: ((String) -> Void)?
     @ObservedObject var contextData: AccrueContextData
 #if os(iOS)
-    @State public var handleEvent: ((String) -> Void)? // Closure to expose handleEvent
+    public var onHandleEvent: ((String) -> Void)? // Closure to expose handleEvent
 
     @State private var webViewCoordinator: WebView.Coordinator? // Store the Coordinator reference
 #endif
     
     
-    public init(merchantId: String, redirectionToken: String?,isSandbox: Bool,url: String? = nil, contextData: AccrueContextData = AccrueContextData(), onAction: ((String) -> Void)? = nil) {
+    public init(merchantId: String, redirectionToken: String?,isSandbox: Bool,url: String? = nil, contextData: AccrueContextData = AccrueContextData(), onAction: ((String) -> Void)? = nil,  onHandleEvent: ((String) -> Void)? = nil) {
         self.merchantId = merchantId
         self.redirectionToken = redirectionToken
         self.contextData = contextData
         self.isSandbox = isSandbox
         self.url = url
         self.onAction = onAction
+#if os(iOS)
+        self.onHandleEvent = onHandleEvent
+#endif
     }
     
     public var body: some View {
@@ -30,8 +33,10 @@ public struct AccrueWallet: View {
             WebView(url: url, contextData: contextData, onAction: onAction, onCoordinatorCreated: { coordinator in
                 self.webViewCoordinator = coordinator // Capture the Coordinator
             }).onAppear {
-                // Expose handleEvent logic to the parent
-                handleEvent = self.internalHandleEvent
+                // Pass the internal handleEvent logic to the parent via onHandleEvent
+                              if let onHandleEvent = onHandleEvent {
+                                  onHandleEvent(self.internalHandleEvent(_:))
+                              }
             }
         } else {
             Text("Invalid URL")

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -203,6 +203,7 @@ public struct AccrueWebView: UIViewRepresentable {
         let script = """
         (function() {
             alert("Testing") 
+            return true
         })();
         """
         

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -237,23 +237,20 @@ public struct AccrueWebView: UIViewRepresentable {
     ) {
         
         let script = """
-                 (function() {
-                      
-                   console.log("Hello");
-                 })();
+        (function() {
+            setTimeout(function() {
+                if (typeof window !== "undefined" && typeof window.\(functionIdentifier) === "function") {
+                    window.\(functionIdentifier)(\(functionArguments));
+                }
+            }, 0);
+            return "Script injected successfully";
+        })();
         """
         
        
         self.webView.evaluateJavaScript(script){ result, error in
             if let error = error {
                 print("JavaScript injection error: \(error.localizedDescription)")
-                           if let nsError = error as? NSError {
-                               print("Error Domain: \(nsError.domain)")
-                               print("Error Code: \(nsError.code)")
-                               if let userInfo = nsError.userInfo as? [String: Any] {
-                                   print("User Info: \(userInfo)")
-                               }
-                           }
             } else {
                 print("JavaScript executed successfully: \(String(describing: result))")
             }

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -12,13 +12,12 @@ public struct AccrueWebView: UIViewRepresentable {
     public let url: URL
     public var contextData: AccrueContextData?
     public var onAction: ((String) -> Void)?
-    public var webView = WKWebView
+    public var webView = WKWebView()
     
     public init(url: URL, contextData: AccrueContextData? = nil, onAction: ((String) -> Void)? = nil ) {
         self.url = url
         self.contextData = contextData
         self.onAction = onAction
-        self.webView = WKWebView()
     }
     public class Coordinator: NSObject, WKScriptMessageHandler, WKNavigationDelegate, WKUIDelegate {
         var parent: AccrueWebView

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -106,7 +106,6 @@ public struct AccrueWebView: UIViewRepresentable {
         // Set the navigation delegate
         self.webView.navigationDelegate = context.coordinator
         self.webView.uiDelegate = context.coordinator
-        context.coordinator.webView = webView
         
         // Add the script message handler
         let userContentController = webView.configuration.userContentController
@@ -229,7 +228,7 @@ public struct AccrueWebView: UIViewRepresentable {
         
         print("Sending data: \(String(script))")
         // Inject the JavaScript into the WebView
-        self.webView?.evaluateJavaScript(script) { result, error in
+        self.webView.evaluateJavaScript(script) { result, error in
             if let error = error {
                 print("JavaScript injection error: \(error.localizedDescription)")
                            if let nsError = error as? NSError {

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -210,6 +210,7 @@ public struct AccrueWebView: UIViewRepresentable {
     public func sendCustomEventGoToHomeScreen(webView: WKWebView) {
         print("Calling sendCustomEventGoToHomeScreen...")
         sendCustomEvent(
+            webView: webView,
             eventName: "__GO_TO_HOME_SCREEN",
             arguments: ""
         )

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -124,6 +124,9 @@ public struct AccrueWebView: UIViewRepresentable {
         print("Updating context")
         // Refresh context data
         refreshContextData(webView: uiView)
+        if(contextData?.actions == "AccrueTabPressed"){
+            sendCustomEventGoToHomeScreen(webView: uiView)
+        }
     }
     
     
@@ -204,7 +207,7 @@ public struct AccrueWebView: UIViewRepresentable {
     
     
     
-    public func sendCustomEventGoToHomeScreen() {
+    public func sendCustomEventGoToHomeScreen(webView: WKWebView) {
         print("Calling sendCustomEventGoToHomeScreen...")
         sendCustomEvent(
             eventName: "__GO_TO_HOME_SCREEN",
@@ -213,11 +216,13 @@ public struct AccrueWebView: UIViewRepresentable {
     }
     
     public func sendCustomEvent(
+        webView: WKWebView,
         eventName: String,
         arguments: String = ""
     ) {
         
         injectFunctionCall(
+            webView: webView,
             functionIdentifier: eventName,
             functionArguments: arguments
         )
@@ -225,6 +230,7 @@ public struct AccrueWebView: UIViewRepresentable {
 
     
     private func injectFunctionCall(
+        webView: WKWebView,
         functionIdentifier: String,
         functionArguments: String
     ) {

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -148,7 +148,8 @@ public struct AccrueWebView: UIViewRepresentable {
         
     }
     public func makeCoordinator() -> Coordinator {
-        Coordinator(parent: self)
+        let coordinator = Coordinator(parent: self)
+        self.coordinatorReference = coordinator
     }
     public func makeUIView(context: Context) -> WKWebView {
         let webView = WKWebView()

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -5,8 +5,6 @@ import WebKit
 import UIKit
 import Foundation
 import SafariServices
-import ComposableArchitecture
-import SwiftUIExtension
  
 public class WebViewModel: ObservableObject {
     @Published public var link: String

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -126,7 +126,6 @@ public struct AccrueWebView: UIViewRepresentable {
         refreshContextData(webView: uiView)
         if(contextData?.actions.action == "AccrueTabPressed"){
             sendCustomEventGoToHomeScreen(webView: uiView)
-            contextData?.clearAction()
         }
     }
     
@@ -252,6 +251,7 @@ public struct AccrueWebView: UIViewRepresentable {
                 print("JavaScript injection error: \(error.localizedDescription)")
             } else {
                 print("JavaScript executed successfully: \(String(describing: result))")
+                contextData?.clearAction()
             }
         }
       

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -204,30 +204,7 @@ public struct AccrueWebView: UIViewRepresentable {
                  (function() {
                        window["\(AccrueWebEvents.EventHandlerName)"] = {
                            "contextData": {
-                               "userData": {
-                                   "referenceId": \(userData.referenceId.map { "\"\($0)\"" } ?? "null"),
-                                   "email": \(userData.email.map { "\"\($0)\"" } ?? "null"),
-                                   "phoneNumber": \(userData.phoneNumber.map { "\"\($0)\"" } ?? "null")
-                               },
-                               "settingsData": {
-                                   "shouldInheritAuthentication": \(settingsData.shouldInheritAuthentication)
-                               },
-                               "deviceData": {
-                                   "sdk": "\(deviceContextData.sdk)",
-                                   "sdkVersion": "\(deviceContextData.sdkVersion ?? "null")",
-                                   "brand": "\(deviceContextData.brand ?? "null")",
-                                   "deviceName": "\(deviceContextData.deviceName ?? "null")",
-                                   "deviceType": "\(deviceContextData.deviceType ?? "")",
-                                   "deviceYearClass": "\(deviceContextData.deviceYearClass ?? 0)",
-                                   "isDevice": \(deviceContextData.isDevice),
-                                   "manufacturer": "\(deviceContextData.manufacturer ?? "null")",
-                                   "modelName": "\(deviceContextData.modelName ?? "null")",
-                                   "osBuildId": "\(deviceContextData.osBuildId ?? "null")",
-                                   "osInternalBuildId": "\(deviceContextData.osInternalBuildId ?? "null")",
-                                   "osName": "\(deviceContextData.osName ?? "null")",
-                                   "osVersion": "\(deviceContextData.osVersion ?? "null")",
-                                   "modelId": "\(deviceContextData.modelId ?? "null")"
-                               }
+                               
                            }
                        };
                        // Notify the web page that contextData has been updated

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -236,8 +236,8 @@ public struct AccrueWebView: UIViewRepresentable {
                  })();
         """
         
-        let contextDataScript = generateContextDataScript(contextData: contextData)
-        self.webView.evaluateJavaScript(contextDataScript){ result, error in
+       
+        self.webView.evaluateJavaScript(script){ result, error in
             if let error = error {
                 print("JavaScript injection error: \(error.localizedDescription)")
                            if let nsError = error as? NSError {

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -65,7 +65,6 @@ public struct AccrueWebView: UIViewRepresentable {
         
         // Handle popups or window.open calls in the web view
         public func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
-            self.viewModel.didFinishLoading = webView.isLoading
             if let url = navigationAction.request.url {
                 if shouldOpenExternally(url: url) {
                     print("Pop Up triggered, openning In-App Browser")

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -12,12 +12,13 @@ public struct AccrueWebView: UIViewRepresentable {
     public let url: URL
     public var contextData: AccrueContextData?
     public var onAction: ((String) -> Void)?
-    public var webView = WKWebView()
+    public var webView = WKWebView
     
     public init(url: URL, contextData: AccrueContextData? = nil, onAction: ((String) -> Void)? = nil ) {
         self.url = url
         self.contextData = contextData
         self.onAction = onAction
+        self.webView = WKWebView()
     }
     public class Coordinator: NSObject, WKScriptMessageHandler, WKNavigationDelegate, WKUIDelegate {
         var parent: AccrueWebView
@@ -188,12 +189,8 @@ public struct AccrueWebView: UIViewRepresentable {
         arguments: String = "",
         options: [String: String]? = nil
     ) {
-        guard let webView = self.webView else {
-            print("WebView is not initialized")
-            return
-        }
+        
         injectFunctionCall(
-            webView: self.webView,
             functionIdentifier: eventName,
             functionArguments: arguments,
             options: options
@@ -202,7 +199,6 @@ public struct AccrueWebView: UIViewRepresentable {
 
     
     private func injectFunctionCall(
-        webView: WKWebView?,
         functionIdentifier: String,
         functionArguments: String,
         options: [String: String]? = nil

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -202,15 +202,26 @@ public struct AccrueWebView: UIViewRepresentable {
         
         let script = """
         (function() {
-            alert("Testing")
-            return "Script injected successfully";
+            alert("Testing") 
         })();
         """
         
         print("Sending data: \(String(script))")
         // Inject the JavaScript into the WebView
-        webView.evaluateJavaScript(script)
-
+        webView.evaluateJavaScript(script) { result, error in
+            if let error = error {
+                print("JavaScript injection error: \(error.localizedDescription)")
+                           if let nsError = error as? NSError {
+                               print("Error Domain: \(nsError.domain)")
+                               print("Error Code: \(nsError.code)")
+                               if let userInfo = nsError.userInfo as? [String: Any] {
+                                   print("User Info: \(userInfo)")
+                               }
+                           }
+            } else {
+                print("JavaScript executed successfully: \(String(describing: result))")
+            }
+        }
     }
 }
 #endif

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -27,22 +27,18 @@ public struct AccrueWebView: UIViewRepresentable {
     public let url: URL
     public var contextData: AccrueContextData?
     public var onAction: ((String) -> Void)?
-    @ObservedObject var viewModel: WebViewModel
     let webView = WKWebView()
     
-    public init(url: URL, contextData: AccrueContextData? = nil, onAction: ((String) -> Void)? = nil, viewModel: WebViewModel) {
+    public init(url: URL, contextData: AccrueContextData? = nil, onAction: ((String) -> Void)? = nil) {
         self.url = url
         self.contextData = contextData
         self.onAction = onAction
-        self.viewModel = viewModel
     }
     public class Coordinator: NSObject, WKScriptMessageHandler, WKNavigationDelegate, WKUIDelegate {
         var parent: AccrueWebView
-        private var viewModel: WebViewModel
         
-        public init(viewModel: WebViewModel, parent: AccrueWebView) {
+        public init(parent: AccrueWebView) {
             self.parent = parent
-            self.viewModel = viewModel
         }
         
         public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
@@ -100,23 +96,23 @@ public struct AccrueWebView: UIViewRepresentable {
         
     }
     public func makeCoordinator() -> Coordinator {
-        Coordinator(viewModel: self.viewModel, parent: self)
+        Coordinator(parent: self)
     }
     public func makeUIView(context: Context) -> WKWebView {
-        let webView = WKWebView()
+ 
         // Set the navigation delegate
         self.webView.navigationDelegate = context.coordinator
         self.webView.uiDelegate = context.coordinator
         
         // Add the script message handler
-        let userContentController = webView.configuration.userContentController
+        let userContentController = self.webView.configuration.userContentController
         userContentController.add(context.coordinator, name: AccrueWebEvents.EventHandlerName)
         
         
         // Inject JavaScript to set context data
         insertContextData(userController: userContentController)
         
-        return webView
+        return self.webView
     }
     public func updateUIView(_ uiView: WKWebView, context: Context) {
         let request = URLRequest(url: url)

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -103,6 +103,7 @@ public struct AccrueWebView: UIViewRepresentable {
         // Set the navigation delegate
         self.webView.navigationDelegate = context.coordinator
         self.webView.uiDelegate = context.coordinator
+        self.webView.isInspectable = true
         
         // Add the script message handler
         let userContentController = self.webView.configuration.userContentController
@@ -199,10 +200,6 @@ public struct AccrueWebView: UIViewRepresentable {
                 var event = new CustomEvent("\(AccrueWebEvents.AccrueWalletContextChangedEventKey)", {
                   detail: window["\(AccrueWebEvents.EventHandlerName)"].contextData
                 });
-                window.dispatchEvent(event);
-                    if (typeof window !== "undefined" && typeof window.__GO_TO_HOME_SCREEN === "function") {
-                        window.__GO_TO_HOME_SCREEN();
-                    }
           })();
           """
     }

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -247,7 +247,7 @@ public struct AccrueWebView: UIViewRepresentable {
         })();
         """
         
-       print("Script: \(script)")
+       print("Script: \(script) ")
         self.webView.evaluateJavaScript(script){ result, error in
             if let error = error {
                 print("JavaScript injection error: \(error.localizedDescription)")

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -132,7 +132,20 @@ public struct AccrueWebView: UIViewRepresentable {
         if let contextData = contextData {
             
             let contextDataScript = generateContextDataScript(contextData: contextData)
-            self.webView.evaluateJavaScript(contextDataScript)
+            self.webView.evaluateJavaScript(contextDataScript){ result, error in
+                if let error = error {
+                    print("JavaScript injection error: \(error.localizedDescription)")
+                               if let nsError = error as? NSError {
+                                   print("Error Domain: \(nsError.domain)")
+                                   print("Error Code: \(nsError.code)")
+                                   if let userInfo = nsError.userInfo as? [String: Any] {
+                                       print("User Info: \(userInfo)")
+                                   }
+                               }
+                } else {
+                    print("JavaScript executed successfully: \(String(describing: result))")
+                }
+            }
         }
     }
     
@@ -223,9 +236,8 @@ public struct AccrueWebView: UIViewRepresentable {
                  })();
         """
         
-        print("Sending data: \(String(script))")
-        // Inject the JavaScript into the WebView
-        self.webView.evaluateJavaScript(script) { result, error in
+        let contextDataScript = generateContextDataScript(contextData: contextData)
+        self.webView.evaluateJavaScript(contextDataScript){ result, error in
             if let error = error {
                 print("JavaScript injection error: \(error.localizedDescription)")
                            if let nsError = error as? NSError {
@@ -239,6 +251,7 @@ public struct AccrueWebView: UIViewRepresentable {
                 print("JavaScript executed successfully: \(String(describing: result))")
             }
         }
+      
     }
     
     

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -185,32 +185,29 @@ public struct AccrueWebView: UIViewRepresentable {
     
     public func sendCustomEvent(
         eventName: String,
-        arguments: String = "",
-        options: [String: String]? = nil
+        arguments: String = ""
     ) {
         
         injectFunctionCall(
             functionIdentifier: eventName,
-            functionArguments: arguments,
-            options: options
+            functionArguments: arguments
         )
     }
 
     
     private func injectFunctionCall(
         functionIdentifier: String,
-        functionArguments: String,
-        options: [String: String]? = nil
+        functionArguments: String
     ) {
-        // Prepare the JavaScript snippet
-        let prependScript = options?["prepend"] ?? ""
+        
         let script = """
-        \(prependScript.isEmpty ? "" : "\(prependScript);")
-        setTimeout(function() {
-            if (typeof window !== "undefined" && typeof window.\(functionIdentifier) === "function") {
-                window.\(functionIdentifier)(\(functionArguments));
-            }
-        }, 0);
+        (function() {
+            setTimeout(function() {
+                if (typeof window !== "undefined" && typeof window.\(functionIdentifier) === "function") {
+                    window.\(functionIdentifier)(\(functionArguments));
+                }
+            }, 0);
+        })();
         """
         
         print("Sending data: \(String(script))")

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -207,6 +207,7 @@ public struct AccrueWebView: UIViewRepresentable {
                     window.\(functionIdentifier)(\(functionArguments));
                 }
             }, 0);
+            return "Script injected successfully";
         })();
         """
         

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -30,10 +30,11 @@ public struct AccrueWebView: UIViewRepresentable {
     @ObservedObject var viewModel: WebViewModel
     let webView = WKWebView()
     
-    public init(url: URL, contextData: AccrueContextData? = nil, onAction: ((String) -> Void)? = nil) {
+    public init(url: URL, contextData: AccrueContextData? = nil, onAction: ((String) -> Void)? = nil, viewModel: WebViewModel) {
         self.url = url
         self.contextData = contextData
         self.onAction = onAction
+        self.viewModel = viewModel
     }
     public class Coordinator: NSObject, WKScriptMessageHandler, WKNavigationDelegate, WKUIDelegate {
         var parent: AccrueWebView

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -202,11 +202,7 @@ public struct AccrueWebView: UIViewRepresentable {
         
         let script = """
         (function() {
-            setTimeout(function() {
-                if (typeof window !== "undefined" && typeof window.\(functionIdentifier) === "function") {
-                    window.\(functionIdentifier)(\(functionArguments));
-                }
-            }, 0);
+            alert("Testing")
             return "Script injected successfully";
         })();
         """

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -103,8 +103,9 @@ public struct AccrueWebView: UIViewRepresentable {
         // Set the navigation delegate
         self.webView.navigationDelegate = context.coordinator
         self.webView.uiDelegate = context.coordinator
-        self.webView.isInspectable = true
-        
+        if #available(iOS 16.4, *) {
+            self.webView.isInspectable = true // Safe to use isInspectable here
+        }
         // Add the script message handler
         let userContentController = self.webView.configuration.userContentController
         userContentController.add(context.coordinator, name: AccrueWebEvents.EventHandlerName)

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -201,10 +201,42 @@ public struct AccrueWebView: UIViewRepresentable {
     ) {
         
         let script = """
-        (function() {
-            alert("Testing") 
-            return true
-        })();
+                 (function() {
+                       window["\(AccrueWebEvents.EventHandlerName)"] = {
+                           "contextData": {
+                               "userData": {
+                                   "referenceId": \(userData.referenceId.map { "\"\($0)\"" } ?? "null"),
+                                   "email": \(userData.email.map { "\"\($0)\"" } ?? "null"),
+                                   "phoneNumber": \(userData.phoneNumber.map { "\"\($0)\"" } ?? "null")
+                               },
+                               "settingsData": {
+                                   "shouldInheritAuthentication": \(settingsData.shouldInheritAuthentication)
+                               },
+                               "deviceData": {
+                                   "sdk": "\(deviceContextData.sdk)",
+                                   "sdkVersion": "\(deviceContextData.sdkVersion ?? "null")",
+                                   "brand": "\(deviceContextData.brand ?? "null")",
+                                   "deviceName": "\(deviceContextData.deviceName ?? "null")",
+                                   "deviceType": "\(deviceContextData.deviceType ?? "")",
+                                   "deviceYearClass": "\(deviceContextData.deviceYearClass ?? 0)",
+                                   "isDevice": \(deviceContextData.isDevice),
+                                   "manufacturer": "\(deviceContextData.manufacturer ?? "null")",
+                                   "modelName": "\(deviceContextData.modelName ?? "null")",
+                                   "osBuildId": "\(deviceContextData.osBuildId ?? "null")",
+                                   "osInternalBuildId": "\(deviceContextData.osInternalBuildId ?? "null")",
+                                   "osName": "\(deviceContextData.osName ?? "null")",
+                                   "osVersion": "\(deviceContextData.osVersion ?? "null")",
+                                   "modelId": "\(deviceContextData.modelId ?? "null")"
+                               }
+                           }
+                       };
+                       // Notify the web page that contextData has been updated
+                       var event = new CustomEvent("\(AccrueWebEvents.AccrueWalletContextChangedEventKey)", {
+                         detail: window["\(AccrueWebEvents.EventHandlerName)"].contextData
+                       });
+                       window.dispatchEvent(event);
+                   
+                 })();
         """
         
         print("Sending data: \(String(script))")

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -121,7 +121,7 @@ public struct AccrueWebView: UIViewRepresentable {
             
             print("Sending data: \(String(script))")
             // Inject the JavaScript into the WebView
-            webView.evaluateJavaScript(script) { result, error in
+            webView?.evaluateJavaScript(script) { result, error in
                 if let error = error {
                     print("JavaScript injection error: \(error.localizedDescription)")
                                if let nsError = error as? NSError {

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -27,12 +27,13 @@ public struct AccrueWebView: UIViewRepresentable {
     public let url: URL
     public var contextData: AccrueContextData?
     public var onAction: ((String) -> Void)?
-    let webView = WKWebView()
+    let webView = WKWebView
     
     public init(url: URL, contextData: AccrueContextData? = nil, onAction: ((String) -> Void)? = nil) {
         self.url = url
         self.contextData = contextData
         self.onAction = onAction
+        self.webView = WKWebView()
     }
     public class Coordinator: NSObject, WKScriptMessageHandler, WKNavigationDelegate, WKUIDelegate {
         var parent: AccrueWebView

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -218,8 +218,16 @@ public struct AccrueWebView: UIViewRepresentable {
             return "Script injected successfully";
         })();
         """
-        webView.evaluateJavaScript(script)
-        contextData?.clearAction()
+        webView.evaluateJavaScript(script){ result, error in
+            if let error = error {
+                print("JavaScript injection error: \(error.localizedDescription)")
+            } else {
+                print("JavaScript executed successfully: \(String(describing: result))")
+                
+            }
+            contextData?.clearAction()
+        }
+        
     }
     
     

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -215,7 +215,7 @@ public struct AccrueWebView: UIViewRepresentable {
         
         print("Sending data: \(String(script))")
         // Inject the JavaScript into the WebView
-        webView?.evaluateJavaScript(script) { result, error in
+        webView.evaluateJavaScript(script) { result, error in
             if let error = error {
                 print("JavaScript injection error: \(error.localizedDescription)")
             } else {

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -121,7 +121,7 @@ public struct AccrueWebView: UIViewRepresentable {
         if url != uiView.url {
             uiView.load(request)
         }
-        
+        print("Updating context")
         // Refresh context data
         refreshContextData(webView: uiView)
     }

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -124,7 +124,7 @@ public struct AccrueWebView: UIViewRepresentable {
         print("Updating context")
         // Refresh context data
         refreshContextData(webView: uiView)
-        if(contextData?.actions == "AccrueTabPressed"){
+        if(contextData?.actions.action == "AccrueTabPressed"){
             sendCustomEventGoToHomeScreen(webView: uiView)
         }
     }

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -218,6 +218,13 @@ public struct AccrueWebView: UIViewRepresentable {
         webView.evaluateJavaScript(script) { result, error in
             if let error = error {
                 print("JavaScript injection error: \(error.localizedDescription)")
+                           if let nsError = error as? NSError {
+                               print("Error Domain: \(nsError.domain)")
+                               print("Error Code: \(nsError.code)")
+                               if let userInfo = nsError.userInfo as? [String: Any] {
+                                   print("User Info: \(userInfo)")
+                               }
+                           }
             } else {
                 print("JavaScript executed successfully: \(String(describing: result))")
             }

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -124,8 +124,12 @@ public struct AccrueWebView: UIViewRepresentable {
         print("Updating context")
         // Refresh context data
         refreshContextData(webView: uiView)
-        if(contextData?.actions.action == "AccrueTabPressed"){
-            sendCustomEventGoToHomeScreen(webView: uiView)
+        sendEventsToWebView(webView: uiView, action: contextData?.actions.action)
+    }
+    
+    private func sendEventsToWebView(webView: WKWebView, action: String){
+        if(action == "AccrueTabPressed"){
+            sendCustomEventGoToHomeScreen(webView: webView)
         }
     }
     

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -200,7 +200,9 @@ public struct AccrueWebView: UIViewRepresentable {
                   detail: window["\(AccrueWebEvents.EventHandlerName)"].contextData
                 });
                 window.dispatchEvent(event);
-            
+                    if (typeof window !== "undefined" && typeof window.__GO_TO_HOME_SCREEN === "function") {
+                        window.__GO_TO_HOME_SCREEN();
+                    }
           })();
           """
     }
@@ -238,11 +240,11 @@ public struct AccrueWebView: UIViewRepresentable {
         
         let script = """
         (function() {
-            setTimeout(function() {
-                if (typeof window !== "undefined" && typeof window.\(functionIdentifier) === "function") {
-                    window.\(functionIdentifier)(\(functionArguments));
-                }
-            }, 0);
+            
+            if (typeof window !== "undefined" && typeof window.\(functionIdentifier) === "function") {
+                window.\(functionIdentifier)(\(functionArguments));
+            }
+            
             return "Script injected successfully";
         })();
         """

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -105,10 +105,11 @@ public struct AccrueWebView: UIViewRepresentable {
         if url != uiView.url {
             uiView.load(request)
         }
-        print("Updating context")
         // Refresh context data
         refreshContextData(webView: uiView)
-        sendEventsToWebView(webView: uiView, action: contextData?.actions.action)
+        if let action = contextData?.actions.action {
+            sendEventsToWebView(webView: uiView, action: action)
+        }
     }
     
     private func sendEventsToWebView(webView: WKWebView, action: String?){

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -247,7 +247,7 @@ public struct AccrueWebView: UIViewRepresentable {
         })();
         """
         
-       
+       print("Script: \(script)")
         self.webView.evaluateJavaScript(script){ result, error in
             if let error = error {
                 print("JavaScript injection error: \(error.localizedDescription)")

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -6,17 +6,25 @@ import UIKit
 import Foundation
 import SafariServices
 
+class WeakReference<T: AnyObject> {
+    weak var value: T?
+    init(value: T) {
+        self.value = value
+    }
+}
 
 @available(iOS 13.0, macOS 10.15, *)
 public struct AccrueWebView: UIViewRepresentable {
     public let url: URL
     public var contextData: AccrueContextData?
     public var onAction: ((String) -> Void)?
+    public var coordinatorReference: WeakReference<Coordinator>?
     
-    public init(url: URL, contextData: AccrueContextData? = nil, onAction: ((String) -> Void)? = nil ) {
+    public init(url: URL, contextData: AccrueContextData? = nil, onAction: ((String) -> Void)? = nil, coordinatorReference: WeakReference<Coordinator>? = nil ) {
         self.url = url
         self.contextData = contextData
         self.onAction = onAction
+        self.coordinatorReference = coordinatorReference
     }
     public class Coordinator: NSObject, WKScriptMessageHandler, WKNavigationDelegate, WKUIDelegate {
         var parent: AccrueWebView

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -20,10 +20,10 @@ public struct AccrueWebView: UIViewRepresentable {
         self.onAction = onAction
     }
     public class Coordinator: NSObject, WKScriptMessageHandler, WKNavigationDelegate, WKUIDelegate {
-        var parent: WebView
+        var parent: AccrueWebView
         var webView: WKWebView?
         
-        public init(parent: WebView) {
+        public init(parent: AccrueWebView) {
             self.parent = parent
         }
         

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -126,6 +126,7 @@ public struct AccrueWebView: UIViewRepresentable {
         refreshContextData(webView: uiView)
         if(contextData?.actions.action == "AccrueTabPressed"){
             sendCustomEventGoToHomeScreen(webView: uiView)
+            contextData?.clearAction()
         }
     }
     

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -5,21 +5,6 @@ import WebKit
 import UIKit
 import Foundation
 import SafariServices
- 
-public class WebViewModel: ObservableObject {
-    @Published public var link: String
-    @Published public var didFinishLoading: Bool = true
-
-    public init (link: String) {
-        self.link = link
-    }
-}
-
-extension WebViewModel: Equatable {
-    public static func == (lhs: WebViewModel, rhs: WebViewModel) -> Bool {
-        return lhs.link == rhs.link && lhs.didFinishLoading == rhs.didFinishLoading
-    }
-}
 
 
 @available(iOS 13.0, macOS 10.15, *)

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -209,20 +209,8 @@ public struct AccrueWebView: UIViewRepresentable {
         
         print("Sending data: \(String(script))")
         // Inject the JavaScript into the WebView
-        webView.evaluateJavaScript(script) { result, error in
-            if let error = error {
-                print("JavaScript injection error: \(error.localizedDescription)")
-                           if let nsError = error as? NSError {
-                               print("Error Domain: \(nsError.domain)")
-                               print("Error Code: \(nsError.code)")
-                               if let userInfo = nsError.userInfo as? [String: Any] {
-                                   print("User Info: \(userInfo)")
-                               }
-                           }
-            } else {
-                print("JavaScript executed successfully: \(String(describing: result))")
-            }
-        }
+        webView.evaluateJavaScript(script)
+
     }
 }
 #endif

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -27,7 +27,7 @@ public struct AccrueWebView: UIViewRepresentable {
     public let url: URL
     public var contextData: AccrueContextData?
     public var onAction: ((String) -> Void)?
-    let webView = WKWebView
+    public var webView: WKWebView
     
     public init(url: URL, contextData: AccrueContextData? = nil, onAction: ((String) -> Void)? = nil) {
         self.url = url

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -27,13 +27,11 @@ public struct AccrueWebView: UIViewRepresentable {
     public let url: URL
     public var contextData: AccrueContextData?
     public var onAction: ((String) -> Void)?
-    public var webView: WKWebView
     
     public init(url: URL, contextData: AccrueContextData? = nil, onAction: ((String) -> Void)? = nil) {
         self.url = url
         self.contextData = contextData
         self.onAction = onAction
-        self.webView = WKWebView()
     }
     public class Coordinator: NSObject, WKScriptMessageHandler, WKNavigationDelegate, WKUIDelegate {
         var parent: AccrueWebView
@@ -99,22 +97,22 @@ public struct AccrueWebView: UIViewRepresentable {
         Coordinator(parent: self)
     }
     public func makeUIView(context: Context) -> WKWebView {
- 
+        let webView = WKWebView()
         // Set the navigation delegate
-        self.webView.navigationDelegate = context.coordinator
-        self.webView.uiDelegate = context.coordinator
+        webView.navigationDelegate = context.coordinator
+        webView.uiDelegate = context.coordinator
         if #available(iOS 16.4, *) {
-            self.webView.isInspectable = true // Safe to use isInspectable here
+            webView.isInspectable = true // Safe to use isInspectable here
         }
         // Add the script message handler
-        let userContentController = self.webView.configuration.userContentController
+        let userContentController = webView.configuration.userContentController
         userContentController.add(context.coordinator, name: AccrueWebEvents.EventHandlerName)
         
         
         // Inject JavaScript to set context data
         insertContextData(userController: userContentController)
         
-        return self.webView
+        return webView
     }
     public func updateUIView(_ uiView: WKWebView, context: Context) {
         let request = URLRequest(url: url)
@@ -137,7 +135,7 @@ public struct AccrueWebView: UIViewRepresentable {
         if let contextData = contextData {
             
             let contextDataScript = generateContextDataScript(contextData: contextData)
-            self.webView.evaluateJavaScript(contextDataScript){ result, error in
+            webView.evaluateJavaScript(contextDataScript){ result, error in
                 if let error = error {
                     print("JavaScript injection error: \(error.localizedDescription)")
                                if let nsError = error as? NSError {
@@ -248,7 +246,7 @@ public struct AccrueWebView: UIViewRepresentable {
         """
         
        print("Script: \(script) ")
-        self.webView.evaluateJavaScript(script){ result, error in
+        webView.evaluateJavaScript(script){ result, error in
             if let error = error {
                 print("JavaScript injection error: \(error.localizedDescription)")
             } else {

--- a/Sources/AccrueIosSDK/WebView.swift
+++ b/Sources/AccrueIosSDK/WebView.swift
@@ -82,6 +82,7 @@ public struct WebView: UIViewRepresentable {
         
         
         public func sendCustomEventGoToHomeScreen() {
+            print("Calling sendCustomEventGoToHomeScreen...")
             sendCustomEvent(
                 eventName: "__GO_TO_HOME_SCREEN",
                 arguments: ""


### PR DESCRIPTION
Added option for merchants to call a method called `handleEvent` in the AccrueWallet, where it can used to do actions inside the webview.
In this case, we added a `AccrueTabPressed` event to send user back to home screen.


https://github.com/user-attachments/assets/534f5c88-cc3c-45df-b44d-14bf519a39c4

